### PR TITLE
[Reviewer: Andy] Switch from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
-from distutils.core import setup
-
+from setuptools import setup, find_packages
 
 setup(
     name='telephus',


### PR DESCRIPTION
(I needed `setup.py bdist_egg` to work, which needs setuptools.)
